### PR TITLE
Create launch setup without Gazebo, and new planning package

### DIFF
--- a/projects/launch/plan_victims.launch.py
+++ b/projects/launch/plan_victims.launch.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+#
+# Author: Enrico Saccon  enrico.saccon [at] unitn.it
+
+import os
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.actions import OpaqueFunction, DeclareLaunchArgument, IncludeLaunchDescription
+from launch import LaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+import launch.logging
+import logging
+
+def print_env(context):
+    print(__file__)
+    for key in context.launch_configurations.keys():
+        print("\t", key, context.launch_configurations[key])
+    return
+
+def check_map(context):
+    from pathlib import Path
+    map_name = Path(context.launch_configurations['map_file'])
+    world_name = Path(context.launch_configurations['gazebo_world_file'])
+    if map_name.stem != world_name.stem:
+        raise Exception("[{}] Map `{}` does not match world `{}`".format(__file__, map_name.stem, world_name.stem))
+    return
+
+def get_map_name(context):
+    map_name = Path(context.launch_configurations['map_file']).stem
+    context.launch_configurations['map_name'] = map_name
+    return
+
+def generate_launch_description():
+    # launch.logging.launch_config.level = logging.DEBUG
+
+    shelfino_desc_pkg  = get_package_share_directory('shelfino_description')
+    shelfino_nav2_pkg  = get_package_share_directory('shelfino_navigation')
+    shelfino_gaze_pkg  = get_package_share_directory('shelfino_gazebo')
+    map_env_pkg        = get_package_share_directory('map_pkg')
+
+    nav2_params_file_path    = os.path.join(shelfino_nav2_pkg, 'config', 'shelfino.yaml')
+    map_env_params_file_path = os.path.join(map_env_pkg, 'config', 'map_config.yaml')
+
+    # General arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+    shelfino_id  = LaunchConfiguration('shelfino_id', default='0')
+
+    # Gazebo simulation arguments
+    use_gui           = LaunchConfiguration('use_gui', default='false')
+    use_rviz          = LaunchConfiguration('use_rviz', default='true')
+    rviz_config_file  = LaunchConfiguration('rviz_config_file', default=os.path.join(shelfino_desc_pkg, 'rviz', 'shelfino.rviz'))
+    gazebo_world_file = LaunchConfiguration('gazebo_world_file', default=os.path.join(shelfino_gaze_pkg, 'worlds', 'hexagon.world'))
+    robot_model_file  = LaunchConfiguration('robot_model_file', default=os.path.join(shelfino_desc_pkg, 'models', 'shelfino', 'model.sdf.xacro'))
+
+    # Navigation arguments
+    map_file = LaunchConfiguration('map_file', default=os.path.join(shelfino_nav2_pkg, 'maps', 'hexagon.yaml'))
+    nav2_params_file = LaunchConfiguration('nav2_params_file', default=nav2_params_file_path)
+    nav2_rviz_config_file = LaunchConfiguration('nav2_rviz_config_file', default=os.path.join(shelfino_nav2_pkg, 'rviz', 'shelfino_nav.rviz'))
+
+    # Map package arguments
+    map_env_params_file = LaunchConfiguration('map_env_params_file', default=map_env_params_file_path)
+
+    shelfino_name = PythonExpression(["'", 'shelfino', shelfino_id, "'"])
+
+    # Declare LaunchArguments for exposing launching arguments
+    launch_args = [
+        # General arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='Use simulation (Gazebo) clock if true'
+        ),
+        DeclareLaunchArgument(
+            'shelfino_id',
+            default_value=shelfino_id,
+            description='ID of the robot'
+        ),
+
+        # Gazebo simulation arguments
+        DeclareLaunchArgument(
+            'use_gui',
+            default_value=use_gui,
+            choices=['true', 'false'],
+            description='Flag to enable gazebo visualization'
+        ),
+        DeclareLaunchArgument(
+            'use_rviz',
+            default_value=use_rviz,
+            choices=['true', 'false'],
+            description='Flag to enable rviz visualization'
+        ),
+        DeclareLaunchArgument(
+            'rviz_config_file',
+            default_value=rviz_config_file,
+            # choices=['empty', 'povo', 'hexagon'],
+            description='Configuration file for rviz'
+        ),
+        DeclareLaunchArgument(
+            'gazebo_world_file',
+            default_value=gazebo_world_file,
+            # choices=['empty', 'povo', 'hexagon'],
+            description='World used in the gazebo simulation'
+        ),
+        DeclareLaunchArgument(
+            'robot_model_file',
+            default_value=robot_model_file,
+            description='Model used in the gazebo simulation'
+        ),
+
+        # Navigation arguments
+        DeclareLaunchArgument(
+            'map_file',
+            default_value=map_file,
+            description='Full path to map file to load'
+        ),
+
+        # Map package arguments
+        DeclareLaunchArgument(
+            'map_env_params_file',
+            default_value=map_env_params_file_path,
+            description='Full path to the map_pkg params file to use'
+        ),
+    ]
+
+    # List of nodes to launch
+    nodes = [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(shelfino_desc_pkg, 'launch'),
+                '/rsp.launch.py']
+            ),
+            launch_arguments= {
+                'use_sim_time': use_sim_time,
+                'robot_id': shelfino_id,
+            }.items()
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(shelfino_gaze_pkg, 'launch'),
+                '/shelfino_no_gazebo.launch.py']
+            ),
+            launch_arguments= {
+                'use_sim_time': use_sim_time,
+                'robot_id': shelfino_id,
+                'use_gui': use_gui,
+                'use_rviz': use_rviz,
+                'rviz_config_file': rviz_config_file,
+                'gazebo_world_file': gazebo_world_file,
+                'robot_model_file': robot_model_file,
+            }.items()
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(shelfino_nav2_pkg, 'launch'),
+                '/shelfino_nav.launch.py']
+            ),
+            launch_arguments= {
+                'use_sim_time': use_sim_time,
+                'robot_id': shelfino_id,
+                'map_file' : map_file,
+                'nav2_params_file' : nav2_params_file,
+                'rviz_config_file': nav2_rviz_config_file,
+            }.items()
+        ),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([
+                os.path.join(map_env_pkg, 'launch'),
+                '/map_env.launch.py']
+            ),
+            launch_arguments= {
+                'map_env_params_file': map_env_params_file,
+                'use_gui': use_gui,
+            }.items()
+        ),
+        Node(
+            package='shelfino_planning',
+            executable='static_robot_state',
+            name='static_robot_state',
+            output='screen',
+            namespace= shelfino_name,
+        ),
+    ]
+
+    # LaunchDescription with the additional launch files
+    ld = LaunchDescription()
+
+    for launch_arg in launch_args:
+        ld.add_action(launch_arg)
+
+    ld.add_action(OpaqueFunction(function=check_map))
+    ld.add_action(OpaqueFunction(function=get_map_name))
+    ld.add_action(OpaqueFunction(function=print_env))
+
+    for node in nodes:
+        ld.add_action(node)
+
+    return ld

--- a/shelfino_gazebo/launch/shelfino_no_gazebo.launch.py
+++ b/shelfino_gazebo/launch/shelfino_no_gazebo.launch.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+#
+# Author: Placido Falqueto   placido.falqueto [at] unitn.it
+# Maintainer: Enrico Saccon  enrico.saccon [at] unitn.it
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+import logging, launch.logging
+
+def print_env(context):
+    print(__file__)
+    for key in context.launch_configurations.keys():
+        print("\t", key, context.launch_configurations[key])
+    return
+
+def check_exists(context):
+    if not os.path.exists(context.launch_configurations['gazebo_world_file']):
+        raise Exception("[{}] Gazebo world file `{}` does not exist".format(__file__, context.launch_configurations['world']))
+
+    if not os.path.exists(context.launch_configurations['robot_model_file']):
+        raise Exception("[{}] Model of the robot `{}` does not exist".format(__file__, context.launch_configurations['robot_model']))
+
+    if context.launch_configurations['use_rviz']=="true" and \
+        not os.path.exists(context.launch_configurations['rviz_config_file']):
+        raise Exception("[{}] Rviz configuration `{}` does not exist".format(__file__, context.launch_configurations['robot_model']))
+
+    return
+
+def generate_launch_description():
+    # launch.logging.launch_config.level = logging.DEBUG
+
+    gazebo_ros_pkg    = get_package_share_directory('gazebo_ros')
+    shelfino_desc_pkg = get_package_share_directory('shelfino_description')
+    shelfino_gaze_pkg = get_package_share_directory('shelfino_gazebo')
+
+    use_sim_time      = LaunchConfiguration('use_sim_time', default='true')
+    robot_id          = LaunchConfiguration('robot_id', default='G')
+    use_gui           = LaunchConfiguration('use_gui')
+    use_rviz          = LaunchConfiguration('use_rviz')
+    spawn_shelfino    = LaunchConfiguration('spawn_shelfino', default='true')
+    rviz_config_file  = LaunchConfiguration('rviz_config_file',
+        default=PythonExpression(["'", os.path.join(shelfino_desc_pkg, 'rviz', 'shelfino'), robot_id, ".rviz'"])
+    )
+    gazebo_world_file = LaunchConfiguration('gazebo_world_file',
+        default=os.path.join(shelfino_gaze_pkg, 'worlds', 'hexagon.world')
+    )
+    robot_model_file  = LaunchConfiguration('robot_model_file',
+        default=os.path.join(shelfino_desc_pkg, 'models', 'shelfino', 'model.sdf.xacro')
+    )
+
+    robot_name = PythonExpression(["'", 'shelfino', robot_id, "'"])
+    model_output = PythonExpression(["'", os.path.join(shelfino_desc_pkg, 'models', 'shelfino'), robot_id, ".sdf'"])
+
+    # TODO move models to shelfino_gazebo
+    os.environ["GAZEBO_MODEL_PATH"] = os.path.join(shelfino_desc_pkg, 'models')
+
+    # rviz_config = PythonExpression(["'", os.path.join(get_package_share_directory('shelfino_description'), 'rviz', 'shelfino'), robot_id, '.rviz', "'"])
+
+    def evaluate_rviz(context, *args, **kwargs):
+        """
+        Replace shelfinoX with the robot name in the rviz configuration file and
+        sets the rviz_config_file to the new file
+        """
+        rn = 'shelfino' + context.launch_configurations['robot_id']
+        rviz_path = context.launch_configurations['rviz_config_file']
+        cr_path = os.path.join(shelfino_desc_pkg, 'rviz', 'shelfino') + context.launch_configurations['robot_id'] + '.rviz'
+
+        print("[{}] Replacing shelfinoX with {} from file {} to file {}".format(__file__, rn, rviz_path, cr_path))
+
+        with open(rviz_path,'r') as f_in:
+            filedata = f_in.read()
+            newdata = filedata.replace("shelfinoX", rn)
+            with open(cr_path,'w+') as f_out:
+                f_out.write(newdata)
+
+        context.launch_configurations['rviz_config_file'] = cr_path
+
+        return
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            name='use_sim_time',
+            default_value='true',
+            description='Flag to enable use of simulation (Gazebo) clock'
+        ),
+        DeclareLaunchArgument(
+            name='robot_id',
+            default_value='0',
+            description='ID of the robot'
+        ),
+        DeclareLaunchArgument(
+            name='use_gui',
+            default_value='true',
+            choices=['true', 'false'],
+            description='Flag to enable gazebo visualization'
+        ),
+        DeclareLaunchArgument(
+            name='use_rviz',
+            default_value='true',
+            choices=['true', 'false'],
+            description='Flag to enable rviz visualization'
+        ),
+        DeclareLaunchArgument(
+            name='spawn_shelfino',
+            default_value='true',
+            choices=['true', 'false'],
+            description='Flag to enable spawning of the robot'
+        ),
+        DeclareLaunchArgument(
+            name='rviz_config_file',
+            default_value=rviz_config_file,
+            description='Path to the rviz configuration file, used only if use_rviz=true'
+        ),
+        DeclareLaunchArgument(
+            name='gazebo_world_file',
+            default_value=gazebo_world_file, # choices=['empty', 'povo', 'hexagon'],
+            description='World used in the gazebo simulation'
+        ),
+        DeclareLaunchArgument(
+            name='robot_model_file',
+            default_value=robot_model_file,
+            description='Model used in the gazebo simulation'
+        ),
+
+        OpaqueFunction(function=print_env),
+        OpaqueFunction(function=check_exists),
+        OpaqueFunction(function=evaluate_rviz),
+
+        ExecuteProcess(
+            cmd=[[
+                'xacro ',
+                robot_model_file,
+                ' robot_id:=',
+                robot_id,
+                ' > ',
+                model_output
+            ]],
+            shell=True,
+            condition=IfCondition(spawn_shelfino)
+        ),
+
+        # IncludeLaunchDescription(
+        #     PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
+        #     launch_arguments={'use_sim_time': use_sim_time,
+        #                       'robot_id': robot_id}.items()
+        # ),
+
+        Node(
+            package='rviz2',
+            executable='rviz2',
+            arguments=['-d', rviz_config_file],
+            condition=IfCondition(use_rviz),
+        ),
+
+        # Node(
+        #     package='get_positions',
+        #     executable='get_positions',
+        #     namespace=robot_name,
+        # ),
+    ])

--- a/shelfino_planning/CMakeLists.txt
+++ b/shelfino_planning/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.8)
+project(shelfino_planning)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+
+install(DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# list of nodes
+set(NODES
+  static_robot_state
+)
+
+#add_library(${PROJECT_NAME}_lib SHARED
+#)
+
+#target_include_directories(${PROJECT_NAME}_lib PUBLIC
+#  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#  $<INSTALL_INTERFACE:include>)
+
+#target_compile_features(${PROJECT_NAME}_lib PUBLIC c_std_99 cxx_std_17)
+
+#ament_target_dependencies(
+#  ${PROJECT_NAME}_lib
+#  "rclcpp"
+#  "std_msgs"
+#  "nav_msgs"
+#  "tf2"
+#  "tf2_ros"
+#  "geometry_msgs"
+#)
+
+
+# build nodes
+foreach(NODE ${NODES})
+  add_executable(${NODE} src/${NODE}.cpp)
+
+  target_include_directories(${NODE} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+  target_compile_features(${NODE} PUBLIC c_std_99 cxx_std_17)
+
+  # target_link_libraries(${NODE} ${PROJECT_NAME}_lib)
+
+  ament_target_dependencies(
+    ${NODE}
+    "rclcpp"
+    "std_msgs"
+    "nav_msgs"
+    "tf2"
+    "tf2_ros"
+    "geometry_msgs"
+    "tf2_geometry_msgs"
+  )
+
+  install(TARGETS ${NODE}
+    DESTINATION lib/${PROJECT_NAME})
+endforeach()
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/shelfino_planning/package.xml
+++ b/shelfino_planning/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>shelfino_planning</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="christian@todo.todo">christian</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/shelfino_planning/src/static_robot_state.cpp
+++ b/shelfino_planning/src/static_robot_state.cpp
@@ -1,0 +1,95 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unistd.h>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <random>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/header.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+
+class StaticRobotState : public rclcpp::Node
+{
+private:
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr publisher_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr initial_pose_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::string node_namespace;
+
+  double initial_x = 0.0;
+  double initial_y = 0.0;
+  double initial_yaw = 0.0;
+
+public:
+  StaticRobotState() : Node("static_robot_state")
+  {
+    this->node_namespace = this->get_namespace();
+
+    this->tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+    this->publisher_ = this->create_publisher<nav_msgs::msg::Odometry>("/odom", 10);
+    this->timer_ = this->create_wall_timer(std::chrono::milliseconds(50), std::bind(&StaticRobotState::publish_tf, this));
+
+    this->initial_pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+      this->node_namespace + "/initialpose", 10, std::bind(&StaticRobotState::initial_pose_cb, this, std::placeholders::_1));
+  }
+
+private:
+  void publish_tf();
+  void initial_pose_cb(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+};
+
+void StaticRobotState::publish_tf() {
+  rclcpp::Time now = this->get_clock()->now();
+
+  geometry_msgs::msg::TransformStamped t;
+  t.header.stamp = now;
+  t.transform.rotation.w = 1.0;
+
+  // Zero transform from /map -> /shelfinoX/odom
+  t.header.frame_id = "map";
+  t.child_frame_id = node_namespace + "/odom";
+  this->tf_broadcaster_->sendTransform(t);
+
+  // Initial transform from /shelfinoX/odom -> /shelfinoX/base_link
+  t.transform.translation.x = initial_x;
+  t.transform.translation.y = initial_y;
+  tf2::Quaternion rot;
+  rot.setRPY(0.0, 0.0, initial_yaw);
+  t.transform.rotation = tf2::toMsg(rot);
+  t.header.frame_id = node_namespace + "/odom";
+  t.child_frame_id = node_namespace + "/base_link";
+  this->tf_broadcaster_->sendTransform(t);
+}
+
+void StaticRobotState::initial_pose_cb(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
+  this->initial_x = msg->pose.pose.position.x;
+  this->initial_y = msg->pose.pose.position.y;
+  tf2::Quaternion q;
+  tf2::fromMsg(msg->pose.pose.orientation, q);
+  this->initial_yaw = q.getAngle();
+  RCLCPP_INFO(this->get_logger(), "Initial pose set to x: %f, y: %f, yaw: %f", this->initial_x, this->initial_y, this->initial_yaw);
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  // Create the node
+  auto node = std::make_shared<StaticRobotState>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Run `ros2 launch projects plan_victims.launch.py`.
This will run everything but gazebo, and the static_robot_state node that properly publishes tf transforms in place of gazebo. This is just for evaluating planning algorithms, since the robot is not actually simulated so it can't actually navigate anywhere.